### PR TITLE
1.1.0: Adds area filtering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_C_COMPILER_ID}" MATCHES
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -march=native -ffast-math")
 endif()
 
-if(ENABLE_SIMD)
+if(FALSE)
     message(STATUS "SIMD enabled.")
 
     add_compile_definitions(ENABLE_SIMD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_C_COMPILER_ID}" MATCHES
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -march=native -ffast-math")
 endif()
 
-if(FALSE)
+if(ENABLE_SIMD)
     message(STATUS "SIMD enabled.")
 
     add_compile_definitions(ENABLE_SIMD)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ print(tinyscaler.scale(img, (32, 32)))
 
 ## Notes
 
-**New since 1.1.0: Supports area filtering**
+**New since 1.1.0: Supports area filtering. It is now the default filtering method as well**
 
 TinyScaler supports mode='area', mode='bilinear', and mode='nearest' filtering. It also allows one to pass a destination buffer in order to avoid duplicate memory allocations.
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ print(tinyscaler.scale(img, (32, 32)))
 
 ## Notes
 
-TinyScaler supports mode='nearest' and mode='bilinear' filtering. It also allows one to pass a destination buffer in order to avoid duplicate memory allocations.
+**New since 1.1.0: Supports area filtering**
+
+TinyScaler supports mode='area', mode='bilinear', and mode='nearest' filtering. It also allows one to pass a destination buffer in order to avoid duplicate memory allocations.
+
+Area filtering is only really useful for downscaling, bilinear will be used even when area filtering is set if upscaling. Area filtering is also likely not worth it when downscaling less than or equal to 2x.
 
 TinyScaler is used through a single function. The full signature is:
 
 ```python
-scale(src : np.ndarray, size : tuple, mode='bilinear', dst : np.ndarray = None)
+scale(src : np.ndarray, size : tuple, mode='area', dst : np.ndarray = None)
 ```
 
 TinyScaler expects a contiguous numpy array. If it is not contiguous, it will throw an error. You can make a non-contiguous numpy array contiguous by calling np.ascontiguousarray.

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ def ffi_build(lib_path, ext_path):
 
         void scale_nearest_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height);
         void scale_bilinear_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height);
+        void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height);
     ''')
 
     ffi.set_source('_scaler_cffi',
@@ -88,7 +89,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='tinyscaler',
-    version='1.0.5',
+    version='1.1.0',
     description='A tiny, simple image scaler',
     long_description='https://github.com/Farama-Foundation/TinyScaler',
     install_requires=[

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -110,6 +110,119 @@ void scale_bilinear_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i3
     }
 }
 
+void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height) {
+    f32 ratio_x = (f32)(src_width - 1) / (f32)dst_width;
+    f32 ratio_y = (f32)(src_height - 1) / (f32)dst_height;
+    i32 src_width4 = src_width << 2;
+    i32 dst_width4 = dst_width << 2;
+
+    i32 area_width = ceilf(ratio_x) + 1;
+    i32 area_height = ceilf(ratio_y) + 1;
+    i32 half_area_width = area_width >> 2;
+    i32 half_area_height = area_height >> 2;
+
+    if ((((size_t)src | (size_t)dst) & 0x0f) == 0) { // Aligned memory
+        for (i32 dst_y = 0; dst_y < dst_height; dst_y++) {
+            f32 src_center_y_f = (dst_y + 0.5f) * ratio_y;
+
+            i32 dst_offset4 = dst_width4 * dst_y;
+
+            f32 over_height = src_center_y_f - floorf(src_center_y_f);
+            f32 over_height1 = 1.0f - over_height;
+
+            for (i32 dst_x = 0; dst_x < dst_width; dst_x++) {
+                f32 src_center_x_f = (dst_x + 0.5f) * ratio_x;
+
+                i32 dst_start = (dst_x << 2) + dst_offset4;
+
+                f32 over_width = src_center_x_f - floorf(src_center_x_f);
+                f32 over_width1 = 1.0f - over_width;
+
+                __m128 res = _mm_set1_ps(0.0f);
+
+                i32 lower_y = max(0, (i32)(src_center_y_f - half_area_height));
+                i32 lower_x = max(0, (i32)(src_center_x_f - half_area_width));
+                i32 upper_y = min(src_height - 1, lower_y + area_height);
+                i32 upper_x = min(src_width - 1, lower_x + area_width);
+
+                f32 weight_total = 0.0f;
+
+                for (i32 area_y = lower_y; area_y <= upper_y; area_y++) {
+                    i32 src_offset4 = src_width4 * area_y;
+
+                    for (i32 area_x = lower_x; area_x <= upper_x; area_x++) {
+                        f32 weight = 1.0f - (area_y == lower_y) * over_height - (area_x == lower_x) * over_width -
+                            (area_y == upper_y) * over_height1 - (area_x == upper_x) * over_width1;
+
+                        i32 src_start = (area_x << 2) + src_offset4;
+
+                        __m128 p = _mm_load_ps(src + src_start);
+
+                        res = _mm_add_ps(res, _mm_mul_ps(p, _mm_set1_ps(weight)));
+                        weight_total += weight;
+                    }
+                }
+
+                f32 div = 1.0f / weight_total;
+
+                res = _mm_mul_ps(res, _mm_set1_ps(div));
+
+                _mm_store_ps(dst + dst_start, res);
+            }
+        }
+    }
+    else { // Unaligned memory
+        for (i32 dst_y = 0; dst_y < dst_height; dst_y++) {
+            f32 src_center_y_f = (dst_y + 0.5f) * ratio_y;
+
+            i32 dst_offset4 = dst_width4 * dst_y;
+
+            f32 over_height = src_center_y_f - floorf(src_center_y_f);
+            f32 over_height1 = 1.0f - over_height;
+
+            for (i32 dst_x = 0; dst_x < dst_width; dst_x++) {
+                f32 src_center_x_f = (dst_x + 0.5f) * ratio_x;
+
+                i32 dst_start = (dst_x << 2) + dst_offset4;
+
+                f32 over_width = src_center_x_f - floorf(src_center_x_f);
+                f32 over_width1 = 1.0f - over_width;
+
+                __m128 res = _mm_set1_ps(0.0f);
+
+                i32 lower_y = max(0, (i32)(src_center_y_f - half_area_height));
+                i32 lower_x = max(0, (i32)(src_center_x_f - half_area_width));
+                i32 upper_y = min(src_height - 1, lower_y + area_height);
+                i32 upper_x = min(src_width - 1, lower_x + area_width);
+
+                f32 weight_total = 0.0f;
+
+                for (i32 area_y = lower_y; area_y <= upper_y; area_y++) {
+                    i32 src_offset4 = src_width4 * area_y;
+
+                    for (i32 area_x = lower_x; area_x <= upper_x; area_x++) {
+                        f32 weight = 1.0f - (area_y == lower_y) * over_height - (area_x == lower_x) * over_width -
+                            (area_y == upper_y) * over_height1 - (area_x == upper_x) * over_width1;
+
+                        i32 src_start = (area_x << 2) + src_offset4;
+
+                        __m128 p = _mm_loadu_ps(src + src_start);
+
+                        res = _mm_add_ps(res, _mm_mul_ps(p, _mm_set1_ps(weight)));
+                        weight_total += weight;
+                    }
+                }
+
+                f32 div = 1.0f / weight_total;
+
+                res = _mm_mul_ps(res, _mm_set1_ps(div));
+
+                _mm_storeu_ps(dst + dst_start, res);
+            }
+        }
+    }
+}
+
 #elif defined(__arm__) // ARM Neon implementation
 
 void scale_bilinear_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height) {
@@ -153,6 +266,67 @@ void scale_bilinear_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i3
             p00 = vaddq_f32(vmulq_f32(p00, ix1), vmulq_f32(p01, ix));
 
             vst1q_f32(dst + dst_start, p00);
+        }
+    }
+}
+
+void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height) {
+    f32 ratio_x = (f32)(src_width - 1) / (f32)dst_width;
+    f32 ratio_y = (f32)(src_height - 1) / (f32)dst_height;
+    i32 src_width4 = src_width << 2;
+    i32 dst_width4 = dst_width << 2;
+
+    i32 area_width = ceilf(ratio_x) + 1;
+    i32 area_height = ceilf(ratio_y) + 1;
+    i32 half_area_width = area_width >> 2;
+    i32 half_area_height = area_height >> 2;
+
+    for (i32 dst_y = 0; dst_y < dst_height; dst_y++) {
+        f32 src_center_y_f = (dst_y + 0.5f) * ratio_y;
+
+        i32 dst_offset4 = dst_width4 * dst_y;
+
+        f32 over_height = src_center_y_f - floorf(src_center_y_f);
+        f32 over_height1 = 1.0f - over_height;
+
+        for (i32 dst_x = 0; dst_x < dst_width; dst_x++) {
+            f32 src_center_x_f = (dst_x + 0.5f) * ratio_x;
+
+            i32 dst_start = (dst_x << 2) + dst_offset4;
+
+            f32 over_width = src_center_x_f - floorf(src_center_x_f);
+            f32 over_width1 = 1.0f - over_width;
+
+            float32x4_t res = vdupq_n_f32(0.0f);
+
+            i32 lower_y = max(0, (i32)(src_center_y_f - half_area_height));
+            i32 lower_x = max(0, (i32)(src_center_x_f - half_area_width));
+            i32 upper_y = min(src_height - 1, lower_y + area_height);
+            i32 upper_x = min(src_width - 1, lower_x + area_width);
+
+            f32 weight_total = 0.0f;
+
+            for (i32 area_y = lower_y; area_y <= upper_y; area_y++) {
+                i32 src_offset4 = src_width4 * area_y;
+
+                for (i32 area_x = lower_x; area_x <= upper_x; area_x++) {
+                    f32 weight = 1.0f - (area_y == lower_y) * over_height - (area_x == lower_x) * over_width -
+                        (area_y == upper_y) * over_height1 - (area_x == upper_x) * over_width1;
+
+                    i32 src_start = (area_x << 2) + src_offset4;
+
+                    float32x4_t p = vld1q_f32(src + src_start);
+
+                    res = vaddq_f32(res, vmulq_f32(p, vdupq_n_f32(weight)));
+                    weight_total += weight;
+                }
+            }
+
+            f32 div = 1.0f / weight_total;
+
+            res = vmulq_f32(res, vdupq_n_f32(div));
+
+            vst1q_f32(dst + dst_start, res);
         }
     }
 }
@@ -210,6 +384,72 @@ void scale_bilinear_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i3
             dst[dst_start + 1] = interp_x1 * pg0 + interp_x * pg1;
             dst[dst_start + 2] = interp_x1 * pb0 + interp_x * pb1;
             dst[dst_start + 3] = interp_x1 * pa0 + interp_x * pa1;
+        }
+    }
+}
+
+void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height) {
+    f32 ratio_x = (f32)(src_width - 1) / (f32)dst_width;
+    f32 ratio_y = (f32)(src_height - 1) / (f32)dst_height;
+    i32 src_width4 = src_width << 2;
+    i32 dst_width4 = dst_width << 2;
+
+    i32 area_width = ceilf(ratio_x) + 1;
+    i32 area_height = ceilf(ratio_y) + 1;
+    i32 half_area_width = area_width >> 2;
+    i32 half_area_height = area_height >> 2;
+
+    for (i32 dst_y = 0; dst_y < dst_height; dst_y++) {
+        f32 src_center_y_f = (dst_y + 0.5f) * ratio_y;
+
+        i32 dst_offset4 = dst_width4 * dst_y;
+
+        f32 over_height = src_center_y_f - floorf(src_center_y_f);
+        f32 over_height1 = 1.0f - over_height;
+
+        for (i32 dst_x = 0; dst_x < dst_width; dst_x++) {
+            f32 src_center_x_f = (dst_x + 0.5f) * ratio_x;
+
+            i32 dst_start = (dst_x << 2) + dst_offset4;
+
+            f32 over_width = src_center_x_f - floorf(src_center_x_f);
+            f32 over_width1 = 1.0f - over_width;
+
+            f32 r = 0.0f;
+            f32 g = 0.0f;
+            f32 b = 0.0f;
+            f32 a = 0.0f;
+
+            i32 lower_y = max(0, (i32)(src_center_y_f - half_area_height));
+            i32 lower_x = max(0, (i32)(src_center_x_f - half_area_width));
+            i32 upper_y = min(src_height - 1, lower_y + area_height);
+            i32 upper_x = min(src_width - 1, lower_x + area_width);
+
+            f32 weight_total = 0.0f;
+
+            for (i32 area_y = lower_y; area_y <= upper_y; area_y++) {
+                i32 src_offset4 = src_width4 * area_y;
+
+                for (i32 area_x = lower_x; area_x <= upper_x; area_x++) {
+                    f32 weight = 1.0f - (area_y == lower_y) * over_height - (area_x == lower_x) * over_width -
+                        (area_y == upper_y) * over_height1 - (area_x == upper_x) * over_width1;
+
+                    i32 src_start = (area_x << 2) + src_offset4;
+
+                    r += weight * src[src_start   ];
+                    g += weight * src[src_start + 1];
+                    b += weight * src[src_start + 2];
+                    a += weight * src[src_start + 3];
+                    weight_total += weight;
+                }
+            }
+
+            f32 div = 1.0f / weight_total;
+
+            dst[dst_start    ] = r * div;
+            dst[dst_start + 1] = g * div;
+            dst[dst_start + 2] = b * div;
+            dst[dst_start + 3] = a * div;
         }
     }
 }

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -122,7 +122,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
 
             i32 src_lower_y = max(0, (i32)src_lower_y_f);
-            i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
+            i32 src_upper_y = min(src_height, (i32)src_upper_y_f + 1);
 
             f32 over_height = src_lower_y_f - (i32)src_lower_y_f;
             f32 over_height1 = 1.0f - (src_upper_y_f - (i32)src_lower_y_f);
@@ -175,7 +175,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
 
             i32 src_lower_y = max(0, (i32)src_lower_y_f);
-            i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
+            i32 src_upper_y = min(src_height, (i32)src_upper_y_f + 1);
 
             f32 over_height = src_lower_y_f - (i32)src_lower_y_f;
             f32 over_height1 = 1.0f - (src_upper_y_f - (i32)src_lower_y_f);
@@ -282,7 +282,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
         f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
 
         i32 src_lower_y = max(0, (i32)src_lower_y_f);
-        i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
+        i32 src_upper_y = min(src_height, (i32)src_upper_y_f + 1);
 
         f32 over_height = src_lower_y_f - (i32)src_lower_y_f;
         f32 over_height1 = 1.0f - (src_upper_y_f - (i32)src_lower_y_f);
@@ -398,7 +398,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
         f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
 
         i32 src_lower_y = max(0, (i32)src_lower_y_f);
-        i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
+        i32 src_upper_y = min(src_height, (i32)src_upper_y_f + 1);
 
         f32 over_height = src_lower_y_f - (i32)src_lower_y_f;
         f32 over_height1 = 1.0f - (src_upper_y_f - (i32)src_lower_y_f);

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -116,44 +116,41 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
     i32 src_width4 = src_width << 2;
     i32 dst_width4 = dst_width << 2;
 
-    i32 area_width = ceilf(ratio_x);
-    i32 area_height = ceilf(ratio_y);
-    i32 half_area_width = ceilf(area_width * 0.5f);
-    i32 half_area_height = ceilf(area_height * 0.5f);
-
     if ((((size_t)src | (size_t)dst) & 0x0f) == 0) { // Aligned memory
         for (i32 dst_y = 0; dst_y < dst_height; dst_y++) {
-            f32 src_center_y_f = (dst_y + 0.5f) * ratio_y;
-            i32 src_center_y = (i32)src_center_y_f;
+            f32 src_lower_y_f = dst_y * ratio_y;
+            f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
+
+            i32 src_lower_y = max(0, (i32)src_lower_y_f);
+            i32 src_upper_y = min(src_height - 1, (i32)src_upper_y_f);
+
+            f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
+            f32 over_height1 = 1.0f - over_height;
 
             i32 dst_offset4 = dst_width4 * dst_y;
 
-            f32 over_height = src_center_y_f - (i32)(src_center_y_f);
-            f32 over_height1 = 1.0f - over_height;
-
             for (i32 dst_x = 0; dst_x < dst_width; dst_x++) {
-                f32 src_center_x_f = (dst_x + 0.5f) * ratio_x;
-                i32 src_center_x = (i32)src_center_x_f;
+                f32 src_lower_x_f = dst_x * ratio_x;
+                f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
+
+                i32 src_lower_x = max(0, (i32)src_lower_x_f);
+                i32 src_upper_x = min(src_width - 1, (i32)src_upper_x_f);
+
+                f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
+                f32 over_width1 = 1.0f - over_width;
 
                 i32 dst_start = (dst_x << 2) + dst_offset4;
 
-                f32 over_width = src_center_x_f - (i32)(src_center_x_f);
-                f32 over_width1 = 1.0f - over_width;
-
                 __m128 res = _mm_set1_ps(0.0f);
-
-                i32 lower_y = max(0, src_center_y - half_area_height);
-                i32 lower_x = max(0, src_center_x - half_area_width);
-                i32 upper_y = min(src_height - 1, src_center_y + half_area_height);
-                i32 upper_x = min(src_width - 1, src_center_x + half_area_width);
 
                 f32 weight_total = 0.0f;
 
-                for (i32 area_y = lower_y; area_y <= upper_y; area_y++) {
+                for (i32 area_y = src_lower_y; area_y <= src_upper_y; area_y++) {
                     i32 src_offset4 = src_width4 * area_y;
 
-                    for (i32 area_x = lower_x; area_x <= upper_x; area_x++) {
-                        f32 weight = (1.0f - (area_y == lower_y) * over_height) * (1.0f - (area_x == lower_x) * over_width) + (1.0f - (area_y == upper_y) * over_height1) * (1.0f - (area_x == upper_x) * over_width1);
+                    for (i32 area_x = src_lower_x; area_x <= src_upper_x; area_x++) {
+                        f32 weight = (1.0f - (area_y == src_lower_y) * over_height) * (1.0f - (area_x == src_lower_x) * over_width) +
+                            (1.0f - (area_y == src_upper_y) * over_height1) * (1.0f - (area_x == src_upper_x) * over_width1);
 
                         i32 src_start = (area_x << 2) + src_offset4;
 
@@ -174,37 +171,39 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
     }
     else { // Unaligned memory
         for (i32 dst_y = 0; dst_y < dst_height; dst_y++) {
-            f32 src_center_y_f = (dst_y + 0.5f) * ratio_y;
-            i32 src_center_y = (i32)src_center_y_f;
+            f32 src_lower_y_f = dst_y * ratio_y;
+            f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
+
+            i32 src_lower_y = max(0, (i32)src_lower_y_f);
+            i32 src_upper_y = min(src_height - 1, (i32)src_upper_y_f);
+
+            f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
+            f32 over_height1 = 1.0f - over_height;
 
             i32 dst_offset4 = dst_width4 * dst_y;
 
-            f32 over_height = src_center_y_f - (i32)(src_center_y_f);
-            f32 over_height1 = 1.0f - over_height;
-
             for (i32 dst_x = 0; dst_x < dst_width; dst_x++) {
-                f32 src_center_x_f = (dst_x + 0.5f) * ratio_x;
-                i32 src_center_x = (i32)src_center_x_f;
+                f32 src_lower_x_f = dst_x * ratio_x;
+                f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
+
+                i32 src_lower_x = max(0, (i32)src_lower_x_f);
+                i32 src_upper_x = min(src_width - 1, (i32)src_upper_x_f);
+
+                f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
+                f32 over_width1 = 1.0f - over_width;
 
                 i32 dst_start = (dst_x << 2) + dst_offset4;
 
-                f32 over_width = src_center_x_f - (i32)(src_center_x_f);
-                f32 over_width1 = 1.0f - over_width;
-
                 __m128 res = _mm_set1_ps(0.0f);
-
-                i32 lower_y = max(0, src_center_y - half_area_height);
-                i32 lower_x = max(0, src_center_x - half_area_width);
-                i32 upper_y = min(src_height - 1, src_center_y + half_area_height);
-                i32 upper_x = min(src_width - 1, src_center_x + half_area_width);
 
                 f32 weight_total = 0.0f;
 
-                for (i32 area_y = lower_y; area_y <= upper_y; area_y++) {
+                for (i32 area_y = src_lower_y; area_y <= src_upper_y; area_y++) {
                     i32 src_offset4 = src_width4 * area_y;
 
-                    for (i32 area_x = lower_x; area_x <= upper_x; area_x++) {
-                        f32 weight = (1.0f - (area_y == lower_y) * over_height) * (1.0f - (area_x == lower_x) * over_width) + (1.0f - (area_y == upper_y) * over_height1) * (1.0f - (area_x == upper_x) * over_width1);
+                    for (i32 area_x = src_lower_x; area_x <= src_upper_x; area_x++) {
+                        f32 weight = (1.0f - (area_y == src_lower_y) * over_height) * (1.0f - (area_x == src_lower_x) * over_width) +
+                            (1.0f - (area_y == src_upper_y) * over_height1) * (1.0f - (area_x == src_upper_x) * over_width1);
 
                         i32 src_start = (area_x << 2) + src_offset4;
 
@@ -278,43 +277,40 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
     i32 src_width4 = src_width << 2;
     i32 dst_width4 = dst_width << 2;
 
-    i32 area_width = ceilf(ratio_x);
-    i32 area_height = ceilf(ratio_y);
-    i32 half_area_width = ceilf(area_width * 0.5f);
-    i32 half_area_height = ceilf(area_height * 0.5f);
-
     for (i32 dst_y = 0; dst_y < dst_height; dst_y++) {
-        f32 src_center_y_f = (dst_y + 0.5f) * ratio_y;
-        i32 src_center_y = (i32)src_center_y_f;
+        f32 src_lower_y_f = dst_y * ratio_y;
+        f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
+
+        i32 src_lower_y = max(0, (i32)src_lower_y_f);
+        i32 src_upper_y = min(src_height - 1, (i32)src_upper_y_f);
+
+        f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
+        f32 over_height1 = 1.0f - over_height;
 
         i32 dst_offset4 = dst_width4 * dst_y;
 
-        f32 over_height = src_center_y_f - (i32)(src_center_y_f);
-        f32 over_height1 = 1.0f - over_height;
-
         for (i32 dst_x = 0; dst_x < dst_width; dst_x++) {
-            f32 src_center_x_f = (dst_x + 0.5f) * ratio_x;
-            i32 src_center_x = (i32)src_center_x_f;
+            f32 src_lower_x_f = dst_x * ratio_x;
+            f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
+
+            i32 src_lower_x = max(0, (i32)src_lower_x_f);
+            i32 src_upper_x = min(src_width - 1, (i32)src_upper_x_f);
+
+            f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
+            f32 over_width1 = 1.0f - over_width;
 
             i32 dst_start = (dst_x << 2) + dst_offset4;
 
-            f32 over_width = src_center_x_f - (i32)(src_center_x_f);
-            f32 over_width1 = 1.0f - over_width;
-
             float32x4_t res = vdupq_n_f32(0.0f);
-
-            i32 lower_y = max(0, src_center_y - half_area_height);
-            i32 lower_x = max(0, src_center_x - half_area_width);
-            i32 upper_y = min(src_height - 1, src_center_y + half_area_height);
-            i32 upper_x = min(src_width - 1, src_center_x + half_area_width);
 
             f32 weight_total = 0.0f;
 
-            for (i32 area_y = lower_y; area_y <= upper_y; area_y++) {
+            for (i32 area_y = src_lower_y; area_y <= src_upper_y; area_y++) {
                 i32 src_offset4 = src_width4 * area_y;
 
-                for (i32 area_x = lower_x; area_x <= upper_x; area_x++) {
-                    f32 weight = (1.0f - (area_y == lower_y) * over_height) * (1.0f - (area_x == lower_x) * over_width) + (1.0f - (area_y == upper_y) * over_height1) * (1.0f - (area_x == upper_x) * over_width1);
+                for (i32 area_x = src_lower_x; area_x <= src_upper_x; area_x++) {
+                    f32 weight = (1.0f - (area_y == src_lower_y) * over_height) * (1.0f - (area_x == src_lower_x) * over_width) +
+                        (1.0f - (area_y == src_upper_y) * over_height1) * (1.0f - (area_x == src_upper_x) * over_width1);
 
                     i32 src_start = (area_x << 2) + src_offset4;
 
@@ -397,46 +393,43 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
     i32 src_width4 = src_width << 2;
     i32 dst_width4 = dst_width << 2;
 
-    i32 area_width = ceilf(ratio_x);
-    i32 area_height = ceilf(ratio_y);
-    i32 half_area_width = ceilf(area_width * 0.5f);
-    i32 half_area_height = ceilf(area_height * 0.5f);
-
     for (i32 dst_y = 0; dst_y < dst_height; dst_y++) {
-        f32 src_center_y_f = (dst_y + 0.5f) * ratio_y;
-        i32 src_center_y = (i32)src_center_y_f;
+        f32 src_lower_y_f = dst_y * ratio_y;
+        f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
+
+        i32 src_lower_y = max(0, (i32)src_lower_y_f);
+        i32 src_upper_y = min(src_height - 1, (i32)src_upper_y_f);
+
+        f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
+        f32 over_height1 = 1.0f - over_height;
 
         i32 dst_offset4 = dst_width4 * dst_y;
 
-        f32 over_height = src_center_y_f - (i32)(src_center_y_f);
-        f32 over_height1 = 1.0f - over_height;
-
         for (i32 dst_x = 0; dst_x < dst_width; dst_x++) {
-            f32 src_center_x_f = (dst_x + 0.5f) * ratio_x;
-            i32 src_center_x = (i32)src_center_x_f;
+            f32 src_lower_x_f = dst_x * ratio_x;
+            f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
+
+            i32 src_lower_x = max(0, (i32)src_lower_x_f);
+            i32 src_upper_x = min(src_width - 1, (i32)src_upper_x_f);
+
+            f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
+            f32 over_width1 = 1.0f - over_width;
 
             i32 dst_start = (dst_x << 2) + dst_offset4;
-
-            f32 over_width = src_center_x_f - (i32)(src_center_x_f);
-            f32 over_width1 = 1.0f - over_width;
 
             f32 r = 0.0f;
             f32 g = 0.0f;
             f32 b = 0.0f;
             f32 a = 0.0f;
 
-            i32 lower_y = max(0, src_center_y - half_area_height);
-            i32 lower_x = max(0, src_center_x - half_area_width);
-            i32 upper_y = min(src_height - 1, src_center_y + half_area_height);
-            i32 upper_x = min(src_width - 1, src_center_x + half_area_width);
-
             f32 weight_total = 0.0f;
 
-            for (i32 area_y = lower_y; area_y <= upper_y; area_y++) {
+            for (i32 area_y = src_lower_y; area_y <= src_upper_y; area_y++) {
                 i32 src_offset4 = src_width4 * area_y;
 
-                for (i32 area_x = lower_x; area_x <= upper_x; area_x++) {
-                    f32 weight = (1.0f - (area_y == lower_y) * over_height) * (1.0f - (area_x == lower_x) * over_width) + (1.0f - (area_y == upper_y) * over_height1) * (1.0f - (area_x == upper_x) * over_width1);
+                for (i32 area_x = src_lower_x; area_x <= src_upper_x; area_x++) {
+                    f32 weight = (1.0f - (area_y == src_lower_y) * over_height) * (1.0f - (area_x == src_lower_x) * over_width) +
+                        (1.0f - (area_y == src_upper_y) * over_height1) * (1.0f - (area_x == src_upper_x) * over_width1);
 
                     i32 src_start = (area_x << 2) + src_offset4;
 

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -122,7 +122,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
 
             i32 src_lower_y = max(0, (i32)src_lower_y_f);
-            i32 src_upper_y = min(src_height - 1, (i32)src_upper_y_f);
+            i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
 
             f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
             f32 over_height1 = 1.0f - over_height;
@@ -134,7 +134,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
                 f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
 
                 i32 src_lower_x = max(0, (i32)src_lower_x_f);
-                i32 src_upper_x = min(src_width - 1, (i32)src_upper_x_f);
+                i32 src_upper_x = min(src_width, (i32)src_upper_x_f);
 
                 f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
                 f32 over_width1 = 1.0f - over_width;
@@ -145,10 +145,10 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
 
                 f32 weight_total = 0.0f;
 
-                for (i32 area_y = src_lower_y; area_y <= src_upper_y; area_y++) {
+                for (i32 area_y = src_lower_y; area_y < src_upper_y; area_y++) {
                     i32 src_offset4 = src_width4 * area_y;
 
-                    for (i32 area_x = src_lower_x; area_x <= src_upper_x; area_x++) {
+                    for (i32 area_x = src_lower_x; area_x < src_upper_x; area_x++) {
                         f32 weight = (1.0f - (area_y == src_lower_y) * over_height) * (1.0f - (area_x == src_lower_x) * over_width) +
                             (1.0f - (area_y == src_upper_y) * over_height1) * (1.0f - (area_x == src_upper_x) * over_width1);
 
@@ -175,7 +175,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
 
             i32 src_lower_y = max(0, (i32)src_lower_y_f);
-            i32 src_upper_y = min(src_height - 1, (i32)src_upper_y_f);
+            i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
 
             f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
             f32 over_height1 = 1.0f - over_height;
@@ -187,7 +187,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
                 f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
 
                 i32 src_lower_x = max(0, (i32)src_lower_x_f);
-                i32 src_upper_x = min(src_width - 1, (i32)src_upper_x_f);
+                i32 src_upper_x = min(src_width, (i32)src_upper_x_f);
 
                 f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
                 f32 over_width1 = 1.0f - over_width;
@@ -198,10 +198,10 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
 
                 f32 weight_total = 0.0f;
 
-                for (i32 area_y = src_lower_y; area_y <= src_upper_y; area_y++) {
+                for (i32 area_y = src_lower_y; area_y < src_upper_y; area_y++) {
                     i32 src_offset4 = src_width4 * area_y;
 
-                    for (i32 area_x = src_lower_x; area_x <= src_upper_x; area_x++) {
+                    for (i32 area_x = src_lower_x; area_x < src_upper_x; area_x++) {
                         f32 weight = (1.0f - (area_y == src_lower_y) * over_height) * (1.0f - (area_x == src_lower_x) * over_width) +
                             (1.0f - (area_y == src_upper_y) * over_height1) * (1.0f - (area_x == src_upper_x) * over_width1);
 
@@ -282,7 +282,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
         f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
 
         i32 src_lower_y = max(0, (i32)src_lower_y_f);
-        i32 src_upper_y = min(src_height - 1, (i32)src_upper_y_f);
+        i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
 
         f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
         f32 over_height1 = 1.0f - over_height;
@@ -294,7 +294,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
 
             i32 src_lower_x = max(0, (i32)src_lower_x_f);
-            i32 src_upper_x = min(src_width - 1, (i32)src_upper_x_f);
+            i32 src_upper_x = min(src_width, (i32)src_upper_x_f);
 
             f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
             f32 over_width1 = 1.0f - over_width;
@@ -305,10 +305,10 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
 
             f32 weight_total = 0.0f;
 
-            for (i32 area_y = src_lower_y; area_y <= src_upper_y; area_y++) {
+            for (i32 area_y = src_lower_y; area_y < src_upper_y; area_y++) {
                 i32 src_offset4 = src_width4 * area_y;
 
-                for (i32 area_x = src_lower_x; area_x <= src_upper_x; area_x++) {
+                for (i32 area_x = src_lower_x; area_x < src_upper_x; area_x++) {
                     f32 weight = (1.0f - (area_y == src_lower_y) * over_height) * (1.0f - (area_x == src_lower_x) * over_width) +
                         (1.0f - (area_y == src_upper_y) * over_height1) * (1.0f - (area_x == src_upper_x) * over_width1);
 
@@ -398,7 +398,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
         f32 src_upper_y_f = (dst_y + 1.0f) * ratio_y;
 
         i32 src_lower_y = max(0, (i32)src_lower_y_f);
-        i32 src_upper_y = min(src_height - 1, (i32)src_upper_y_f);
+        i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
 
         f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
         f32 over_height1 = 1.0f - over_height;
@@ -410,7 +410,7 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
 
             i32 src_lower_x = max(0, (i32)src_lower_x_f);
-            i32 src_upper_x = min(src_width - 1, (i32)src_upper_x_f);
+            i32 src_upper_x = min(src_width, (i32)src_upper_x_f);
 
             f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
             f32 over_width1 = 1.0f - over_width;
@@ -424,10 +424,10 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
 
             f32 weight_total = 0.0f;
 
-            for (i32 area_y = src_lower_y; area_y <= src_upper_y; area_y++) {
+            for (i32 area_y = src_lower_y; area_y < src_upper_y; area_y++) {
                 i32 src_offset4 = src_width4 * area_y;
 
-                for (i32 area_x = src_lower_x; area_x <= src_upper_x; area_x++) {
+                for (i32 area_x = src_lower_x; area_x < src_upper_x; area_x++) {
                     f32 weight = (1.0f - (area_y == src_lower_y) * over_height) * (1.0f - (area_x == src_lower_x) * over_width) +
                         (1.0f - (area_y == src_upper_y) * over_height1) * (1.0f - (area_x == src_upper_x) * over_width1);
 

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -124,8 +124,8 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             i32 src_lower_y = max(0, (i32)src_lower_y_f);
             i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
 
-            f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
-            f32 over_height1 = 1.0f - over_height;
+            f32 over_height = src_lower_y_f - (i32)src_lower_y_f;
+            f32 over_height1 = 1.0f - (src_upper_y_f - (i32)src_lower_y_f);
 
             i32 dst_offset4 = dst_width4 * dst_y;
 
@@ -134,10 +134,10 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
                 f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
 
                 i32 src_lower_x = max(0, (i32)src_lower_x_f);
-                i32 src_upper_x = min(src_width, (i32)src_upper_x_f);
+                i32 src_upper_x = min(src_width, (i32)src_upper_x_f + 1);
 
-                f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
-                f32 over_width1 = 1.0f - over_width;
+                f32 over_width = src_lower_x_f - (i32)src_lower_x_f;
+                f32 over_width1 = 1.0f - (src_upper_x_f - (i32)src_lower_x_f);
 
                 i32 dst_start = (dst_x << 2) + dst_offset4;
 
@@ -177,8 +177,8 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             i32 src_lower_y = max(0, (i32)src_lower_y_f);
             i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
 
-            f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
-            f32 over_height1 = 1.0f - over_height;
+            f32 over_height = src_lower_y_f - (i32)src_lower_y_f;
+            f32 over_height1 = 1.0f - (src_upper_y_f - (i32)src_lower_y_f);
 
             i32 dst_offset4 = dst_width4 * dst_y;
 
@@ -187,10 +187,10 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
                 f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
 
                 i32 src_lower_x = max(0, (i32)src_lower_x_f);
-                i32 src_upper_x = min(src_width, (i32)src_upper_x_f);
+                i32 src_upper_x = min(src_width, (i32)src_upper_x_f + 1);
 
-                f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
-                f32 over_width1 = 1.0f - over_width;
+                f32 over_width = src_lower_x_f - (i32)src_lower_x_f;
+                f32 over_width1 = 1.0f - (src_upper_x_f - (i32)src_lower_x_f);
 
                 i32 dst_start = (dst_x << 2) + dst_offset4;
 
@@ -284,8 +284,8 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
         i32 src_lower_y = max(0, (i32)src_lower_y_f);
         i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
 
-        f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
-        f32 over_height1 = 1.0f - over_height;
+        f32 over_height = src_lower_y_f - (i32)src_lower_y_f;
+        f32 over_height1 = 1.0f - (src_upper_y_f - (i32)src_lower_y_f);
 
         i32 dst_offset4 = dst_width4 * dst_y;
 
@@ -294,10 +294,10 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
 
             i32 src_lower_x = max(0, (i32)src_lower_x_f);
-            i32 src_upper_x = min(src_width, (i32)src_upper_x_f);
+            i32 src_upper_x = min(src_width, (i32)src_upper_x_f + 1);
 
-            f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
-            f32 over_width1 = 1.0f - over_width;
+            f32 over_width = src_lower_x_f - (i32)src_lower_x_f;
+            f32 over_width1 = 1.0f - (src_upper_x_f - (i32)src_lower_x_f);
 
             i32 dst_start = (dst_x << 2) + dst_offset4;
 
@@ -400,8 +400,8 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
         i32 src_lower_y = max(0, (i32)src_lower_y_f);
         i32 src_upper_y = min(src_height, (i32)src_upper_y_f);
 
-        f32 over_height = src_lower_y_f - (i32)(src_lower_y_f);
-        f32 over_height1 = 1.0f - over_height;
+        f32 over_height = src_lower_y_f - (i32)src_lower_y_f;
+        f32 over_height1 = 1.0f - (src_upper_y_f - (i32)src_lower_y_f);
 
         i32 dst_offset4 = dst_width4 * dst_y;
 
@@ -410,10 +410,10 @@ void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 ds
             f32 src_upper_x_f = (dst_x + 1.0f) * ratio_x;
 
             i32 src_lower_x = max(0, (i32)src_lower_x_f);
-            i32 src_upper_x = min(src_width, (i32)src_upper_x_f);
+            i32 src_upper_x = min(src_width, (i32)src_upper_x_f + 1);
 
-            f32 over_width = src_lower_x_f - (i32)(src_lower_x_f);
-            f32 over_width1 = 1.0f - over_width;
+            f32 over_width = src_lower_x_f - (i32)src_lower_x_f;
+            f32 over_width1 = 1.0f - (src_upper_x_f - (i32)src_lower_x_f);
 
             i32 dst_start = (dst_x << 2) + dst_offset4;
 

--- a/src/scaler.h
+++ b/src/scaler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdlib.h>
 #include <math.h>
 #include <memory.h>
 
@@ -15,6 +16,11 @@
 
 #define RGBA32F_SIZE 16 // Byte size of a pixel
 
+#ifndef max
+#define max(a,b) (((a) > (b)) ? (a) : (b))
+#define min(a,b) (((a) < (b)) ? (a) : (b))
+#endif
+
 typedef unsigned char u8;
 typedef int i32;
 typedef float f32;
@@ -23,3 +29,4 @@ typedef double f64;
 // Scalers
 void scale_nearest_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height);
 void scale_bilinear_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height);
+void scale_area_4f32(f32 src[], f32 dst[], i32 src_width, i32 src_height, i32 dst_width, i32 dst_height);


### PR DESCRIPTION
Area filtering for image shrinking is now implemented. It is also the default filtering method now. Bilinear filtering will be used when upscaling even when area filtering is selected, as area filtering isn't needed there.